### PR TITLE
Network perf tuning

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -562,7 +562,10 @@ Connection.prototype._createSocket = function() {
 
   // Disable tcp nagle's algo
   // Default: true, makes small messages faster
-  var noDelay = this.options.noDelay || true;
+  var noDelay = true;
+  if (this.options.hasOwnProperty('noDelay')) {
+    noDelay = this.options.noDelay;
+  }
 
   var resetConnectionTimeout = function () {
     debug && debug('connected so resetting connection timeout');

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -220,6 +220,7 @@ Exchange.prototype.publish = function (routingKey, data, options, callback) {
   options.reserved1  = 0;
 
   var task = this._taskPush(null, function () {
+    self.connection.socket.cork();
     self.connection._sendMethod(self.channel, methods.basicPublish, options);
     // This interface is probably not appropriate for streaming large files.
     // (Of course it's arguable about whether AMQP is the appropriate
@@ -229,6 +230,7 @@ Exchange.prototype.publish = function (routingKey, data, options, callback) {
     // isn't possible with AMQP. This is all to say, don't send big messages.
     // If you need to stream something large, chunk it yourself.
     self.connection._sendBody(self.channel, data, options);
+    self.connection.socket.uncork();
   });
 
   if (self.options.confirm) self._awaitConfirm(task, callback);


### PR DESCRIPTION
Corked publish almost always saves an IP packet per published message (100% improvement for typical small message). It may result in increased memory usage during publish function call, but we shouldn't send that big messages as single chunk anyway.

The other commit is a bug fix in options handling.